### PR TITLE
Fix display of components for files in the background

### DIFF
--- a/ShowComponentsCompatibility.glyphsReporter/Contents/Info.plist
+++ b/ShowComponentsCompatibility.glyphsReporter/Contents/Info.plist
@@ -13,15 +13,15 @@
 	<key>CFBundleName</key>
 	<string>ShowComponentsCompatibility</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.2</string>
+	<string>1.0.3</string>
 	<key>CFBundleVersion</key>
-	<string>5</string>
+	<string>6</string>
 	<key>UpdateFeedURL</key>
 	<string>https://raw.githubusercontent.com/guidoferreyra/ShowComponentsCompatibility/master/ShowComponentsCompatibility.glyphsReporter/Contents/Info.plist</string>
 	<key>productPageURL</key>
 	<string>https://github.com/guidoferreyra/ShowComponentsCompatibility</string>
 	<key>productReleaseNotes</key>
-	<string>Update plugin structure</string>
+	<string>Fix display of components for files in the background</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright, Guido Ferreyra, 2015</string>
 	<key>NSPrincipalClass</key>

--- a/ShowComponentsCompatibility.glyphsReporter/Contents/Resources/plugin.py
+++ b/ShowComponentsCompatibility.glyphsReporter/Contents/Resources/plugin.py
@@ -16,9 +16,9 @@ class ShowComponentsCompatibility (ReporterPlugin):
 	@objc.python_method
 	def checkComponents(self, Layer):
 
-		thisFont = Glyphs.font
-		currentLayer = thisFont.selectedLayers[0]
+		currentLayer = Layer
 		thisGlyph = currentLayer.parent
+		thisFont = thisGlyph.parent
 
 		HandleSize = self.getHandleSize()
 		scale = self.getScale()


### PR DESCRIPTION
The list of components of the active file was shown in all open files. I changed it to get the list of components for each file, so it is now possible to open 2 files side-by-side and compare their components.